### PR TITLE
Update controller_actions.ctp

### DIFF
--- a/Console/Templates/Cakestrap/actions/controller_actions.ctp
+++ b/Console/Templates/Cakestrap/actions/controller_actions.ctp
@@ -137,11 +137,13 @@
  * @return void
  */
 	public function <?php echo $admin; ?>delete($id = null) {
+		if (!$this->request->is('post')) {
+			throw new MethodNotAllowedException();
+		}
 		$this-><?php echo $currentModelName; ?>->id = $id;
 		if (!$this-><?php echo $currentModelName; ?>->exists()) {
 			throw new NotFoundException(__('Invalid <?php echo strtolower($singularHumanName); ?>'));
 		}
-		$this->request->onlyAllow('post', 'delete');
 		if ($this-><?php echo $currentModelName; ?>->delete()) {
 <?php if ($wannaUseSession): ?>
 			$this->Session->setFlash(__('<?php echo ucfirst(strtolower($singularHumanName)); ?> deleted'), 'flash/success');


### PR DESCRIPTION
In newer versions of Cake the "allowOnly" function doesn't exist anymore, it was replaced by that if.
<a href="http://stackoverflow.com/questions/15563902/cakephp-2-3-method-onlyallow-does-not-exist">Visit this link</a> for more info about a more detailed explanation. 
