### PR TITLE
Added missing assignment

### DIFF
--- a/Console/Templates/Cakestrap/actions/controller_actions.ctp
+++ b/Console/Templates/Cakestrap/actions/controller_actions.ctp
@@ -91,6 +91,7 @@
  * @return void
  */
 	public function <?php echo $admin; ?>edit($id = null) {
+        $this-><?php echo $currentModelName; ?>->id = $id;
 		if (!$this-><?php echo $currentModelName; ?>->exists($id)) {
 			throw new NotFoundException(__('Invalid <?php echo strtolower($singularHumanName); ?>'));
 		}


### PR DESCRIPTION
I notice that it was missing an assignment in the `edit()` method, this creates a bug where when you edit an item, it is saved as a new record.
