### PR TITLE
Fixed wrong class name for alert messages

### DIFF
--- a/View/Themed/Cakestrap/Elements/flash/error.ctp
+++ b/View/Themed/Cakestrap/Elements/flash/error.ctp
@@ -1,4 +1,4 @@
-<div class="alert alert-error">
+<div class="alert alert-danger">
 	<button type="button" class="close" data-dismiss="alert">&times;</button>
 	<?php echo $message ?>
 </div><!-- /.alert alert-error -->


### PR DESCRIPTION
Correct class should be 'danger' for error messages
